### PR TITLE
More customization

### DIFF
--- a/codly.typ
+++ b/codly.typ
@@ -224,7 +224,6 @@
           }
 
           set par(justify: false)
-          set align(horizon)
           if config.width-numbers != none {
             place(
               horizon + left,

--- a/codly.typ
+++ b/codly.typ
@@ -18,7 +18,7 @@
 
 // Default language-block style
 #let language-block(name, icon, color) = {
-  let content = name + icon
+  let content = icon + name
   locate(loc => {
     let config = state("codly-config").at(loc)
     style(styles => {

--- a/codly.typ
+++ b/codly.typ
@@ -53,6 +53,10 @@
   // If set to `none`, the numbers column will be disabled.
   width-numbers: 2em,
 
+  // Format of the line numbers.
+  // This is a function applied to the text of every line number.
+  numbers-format: text,
+
   // Whether this code block is breakable.
   breakable: true,
 ) = locate(loc => {
@@ -68,6 +72,7 @@
       zebra-color: zebra-color,
       stroke-width: stroke-width,
       width-numbers: width-numbers,
+      numbers-format: numbers-format,
       breakable: breakable,
       stroke-color: stroke-color,
     ))
@@ -87,6 +92,7 @@
       zebra-color: zebra-color,
       stroke-width: stroke-width,
       width-numbers: width-numbers,
+      numbers-format: numbers-format,
       breakable: breakable,
       stroke-color: stroke-color,
     ))
@@ -206,11 +212,12 @@
           }
 
           set par(justify: false)
+          set align(horizon)
           if config.width-numbers != none {
             place(
-              top + left,
-              dx: -config.width-numbers, 
-              [#(offset + it.number)]
+              horizon + left,
+              dx: -config.width-numbers,
+              (config.numbers-format)[#(offset + it.number)]
             )
           }
           it

--- a/codly.typ
+++ b/codly.typ
@@ -58,6 +58,10 @@
   // Padding of a code block.
   padding: 0.32em,
 
+  // Fill color of lines.
+  // If zebra color is enabled, this is just for odd lines.
+  fill: white,
+
   // The zebra color to use or `none` to disable.
   zebra-color: luma(240),
 
@@ -95,6 +99,7 @@
       default-color: default-color,
       radius: radius,
       padding: padding,
+      fill: fill,
       zebra-color: zebra-color,
       stroke-width: stroke-width,
       width-numbers: width-numbers,
@@ -117,6 +122,7 @@
       radius: radius,
       padding: padding,
       zebra-color: zebra-color,
+      fill: fill,
       stroke-width: stroke-width,
       width-numbers: width-numbers,
       numbers-format: numbers-format,
@@ -200,10 +206,10 @@
         width: 100%,
         height: 1.2em + config.padding * 2,
         inset: (left: config.padding + width, top: config.padding + 0.1em, rest: config.padding),
-        fill: if calc.rem(it.number, 2) == 0 {
+        fill: if config.zebra-color != none and calc.rem(it.number, 2) == 0 {
           config.zebra-color
         } else {
-          white
+          none
         },
         radius: border(it.number, it.count).radius,
         stroke: border(it.number, it.count).stroke,
@@ -241,6 +247,8 @@
       breakable: config.breakable,
       clip: false,
       width: 100%,
+      radius: config.radius,
+      fill: config.fill,
       stack(dir: ttb, ..it.lines)
     )
 


### PR DESCRIPTION
Added 3 new arguments:
- `numbers-format`: a function that formats a line number, by default, it's just `text` and can be easily customized with `text.with(..)`. I set the place alignment to horizon to make the numbers align in the center if they are smaller than the line content.

- `language-block`: same idea but for the language block. To do this, I extracted the default style to it's own function and that's the default. Also the user can use this function to move around the block do whatever.

- `fill`: Color for the lines. Defaults to white. This fill is now applied to the `block` and not each line. If a line it's not a zebra line, it has no fill. Also added radius to the outer block to make the fill don't leak in the corners.