### PR TITLE
Fix position of language-block

### DIFF
--- a/codly.typ
+++ b/codly.typ
@@ -303,7 +303,7 @@
       items.push(style(styles => grid(
         columns: (1fr, measure(language-block, styles).width + 2 * padding),
         line,
-        place(right + horizon, language-block),
+        place(right + horizon, dx: 0.35em, language-block),
       )))
     }
 


### PR DESCRIPTION
Removes the spacing between the `language-block` and the block itself.
Seems to work fine with multiple font sizes.