### PR TITLE
Fix `language-block` argument

### DIFF
--- a/codly.typ
+++ b/codly.typ
@@ -218,7 +218,7 @@
       type(language-block) == function,
       message: "codly: `language-block` must be a function"
     )
-    __codly-language-block.update(language-block)
+    __codly-language-block.update((_) => language-block)
   }
 }
 


### PR DESCRIPTION
Hi,

Great package!

I think currently the `language-block` argument is not working. There is no documentation, but the code comments say this should be a function with three arguments, so I think it's supposed to work like this:

````typst
#import "@preview/codly:0.2.1": *
#show: codly-init.with()
#codly(
  language-block: (name, icon, color) => icon,
  languages: (rust: (name: "Rust", icon: [ICON], color: none)),
)

```rust
pub fn main() {
    println!("Hello, world!");
}
```

````

Compiling:

```
error: missing argument: icon
  ┌─ codly-language-block.typ:4:18
  │
4 │   language-block: (name, icon, color) => icon,
  │                   ^^^^^^^^^^^^^^^^^^^

help: error occurred in this call of function `at`
    ┌─ @preview/codly:0.2.1/codly.typ:246:25
    │
246 │     let language-block = __codly-language-block.at(loc)
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

My pull request at least gets it working again, although the function does require 4 arguments. This might actually be the intended solution as the 4th `loc` arg could be useful. Anyway, I suggest to update on the manual on how it should be used.

````
#import "/submodules/codly/codly.typ": * // change codly.typ:221 to __codly-language-block.update((_) => language-block)
#show: codly-init.with()
#codly(
  language-block: (name, icon, color, loc) => icon,
  languages: (rust: (name: "Rust", icon: [ICON], color: none)),
)
```

```rust
pub fn main() {
    println!("Hello, world!");
}
````

![image](https://github.com/Dherse/codly/assets/7458269/fd3a51d1-6878-4242-b696-cd7c4d042df4)

Cheers,

Henk