### PR TITLE
fix comparison between type and str

### DIFF
--- a/src/args.typ
+++ b/src/args.typ
@@ -86,7 +86,7 @@
   let out = (:)
   let args = json("args.json")
   for (key, arg) in args {
-    if arg.function and function in arg.ty {
+    if arg.function and str(function) in arg.ty {
       panic("codly: `function` is not a valid type for an argument")
     }
     


### PR DESCRIPTION
Fixes warning given by typst 0.13.0:

```
warning: comparing strings with types is deprecated
   ┌─ @preview/codly:1.2.0/src/args.typ:89:24
   │
89 │     if arg.function and function in arg.ty {
   │                         ^^^^^^^^^^^^^^^^^^
   │
   = hint: compare with the literal type instead
   = hint: this comparison will always return `false` in future Typst releases
```

As I couldn't find a way of converting a `str` representation of a type to `type` in typst, I found two solutions:

- `str(function)`
- mapping all possible `type` to `str` by `str(type)`, converting `arg.tv` to `type` with this and then checking `function` against it

The second solution requires mantaining the conversion with new types in case they get included in typst.

The first solution requires taking care of `args.json` in case `str(function)` changes in future versions, which I think its less likely.