### PR TITLE
Add support for PDF/UA-1

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -597,7 +597,7 @@
           hl.tag
         }
 
-        place(hide[#figure(
+        place(hide(pdf.artifact[#figure(
           kind: "codly-referencer",
           supplement: none,
           numbering: (..) => {
@@ -606,7 +606,7 @@
             __codly-trim(referenced)
           },
           []
-        )#hl.label])
+        )#hl.label]))
       } else {
         none
       }
@@ -1598,7 +1598,7 @@
     }
 
     // Always push the formatted line number
-    let l = figure(
+    let l = pdf.artifact(figure(
       kind: "__codly-raw-line",
       numbering: none,
       placement: none,
@@ -1611,7 +1611,7 @@
         line.text,
         box(height: height, width: 0pt) + line.body,
       ) <codly-highlighted>]
-    )
+    ))
 
     lines_to_number.push(line.number + offset)
 
@@ -1632,7 +1632,7 @@
           num
         }
 
-        place(hide[#figure(
+        place(hide(pdf.artifact[#figure(
           kind: "codly-referencer",
           supplement: none,
           numbering: (..) => {
@@ -1641,7 +1641,7 @@
             referenced
           },
           []
-        )#current-annot.label])
+        )#current-annot.label]))
       } else {
         none
       }
@@ -1992,7 +1992,7 @@
 
   block_content
 
-  figure(
+  pdf.artifact(figure(
     kind: "__codly-end-block",
     supplement: none,
     numbering: none,
@@ -2000,7 +2000,7 @@
     outlined: false,
     gap: 0pt,
     caption: none,
-  )[]
+  )[])
 
   if offset != 0 {
     state("codly-offset").update(0)
@@ -2140,22 +2140,22 @@
 #let typst-icon = (
   typ: (
     name: "Typst",
-    icon: box(
+    icon: pdf.artifact(box(
       image("typst-small.png", height: 0.8em),
       baseline: 0.1em,
       inset: 0pt,
       outset: 0pt,
-    ),
+    )),
     color: rgb("#239DAD"),
   ),
   typc: (
     name: "Typst code",
-    icon: box(
+    icon: pdf.artifact(box(
       image("typst-small.png", height: 0.8em),
       baseline: 0.1em,
       inset: 0pt,
       outset: 0pt,
-    ),
+    )),
     color: rgb("#239DAD"),
   ),
 )


### PR DESCRIPTION
Closes https://github.com/Dherse/codly/issues/113.

My first approach was to provide all the missing alt text, which was really not something someone would wanna read anyway. And so I discovered [`pdf.artifact`](https://typst.app/docs/reference/pdf/artifact/) [through @xkevio](https://discord.com/channels/1054443721975922748/1399326777540608041/1444073415135985916). And it definitely falls under the decorative images for the two bottom images, but for the rest... There is no mention of `figure` hacks, but since they are invisible and all, I guess it makes more sense to convert all figures into artifacts as well.

<details><summary>Tested with</summary>

``````typ
#import "@preview/codly:1.3.1": *
#show: codly-init

#set document(title: "Title")

#codly(
  reference-by: "item",
  highlights: ((line: 1, start: 1, label: <this>, tag: [a]),),
  // highlights: ((line: 1, start: 1, label: <this>),),
)
#figure(
```typ
$x = y$

$y = b x + m$
```
, caption: []
) <label>

@label:1

@this

@label

#figure(
```typ
$x = y$

$y = b x + m$
```
, caption: []
) <another>
``````

</details>

Not sure if text of a language should be omitted. Of course, it's not 100% certain the code with this package is a one single thing or not, compared to the default, but either way, reading the language name might be very useful, though would be strange if there are no references to it in the text.

The docs use figures/images, IIRC, so this does not make them PDF/UA-1 compatible, since it's not part of the package.