### PR TITLE
Remove unused code; fix empty code error

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1878,8 +1878,6 @@
     )
   )
 
-  let width_lines_number = calc.max(2, (calc.ceil(calc.log(it.lines.len())) + 1)) * 1em
-
   let line_colors = ()
   for (i, line) in lines_to_number.enumerate() {
     let highlighted = highlighted-by-line.at(line - 1, default: none)


### PR DESCRIPTION
This fixes failing

`````typ
#import "@preview/codly:1.3.1": *
#show: codly-init
```
```
`````

Also, the result of the calculation is not used in the first place.
